### PR TITLE
insertable=false, updatable=false have to be consistent across all jo…

### DIFF
--- a/src/main/java/org/telosys/tools/generator/context/Jpa.java
+++ b/src/main/java/org/telosys/tools/generator/context/Jpa.java
@@ -15,9 +15,6 @@
  */
 package org.telosys.tools.generator.context;
 
-import java.util.LinkedList;
-import java.util.List;
-
 import org.telosys.tools.commons.StrUtil;
 import org.telosys.tools.generator.GeneratorException;
 import org.telosys.tools.generator.context.doc.VelocityMethod;
@@ -27,15 +24,18 @@ import org.telosys.tools.generator.context.names.ContextName;
 import org.telosys.tools.generator.context.tools.AnnotationsBuilder;
 import org.telosys.tools.generator.context.tools.AnnotationsForJPA;
 
+import java.util.LinkedList;
+import java.util.List;
+
 //-------------------------------------------------------------------------------------
 @VelocityObject(
 		contextName=ContextName.JPA,
-		text = { 
+		text = {
 				"Object providing a set of utility functions for JPA (Java Persistence API) code generation",
 				""
 		},
 		since = "2.0.7"
- )
+)
 //-------------------------------------------------------------------------------------
 public class Jpa {
 
@@ -43,7 +43,7 @@ public class Jpa {
 //	private final static int MANY_TO_ONE  = 2 ;
 //	private final static int ONE_TO_MANY  = 3 ;
 //	private final static int MANY_TO_MANY = 4 ;
-	
+
 	private final static List<String> VOID_STRINGS_LIST = new LinkedList<String>();
 
 	//-------------------------------------------------------------------------------------
@@ -52,28 +52,28 @@ public class Jpa {
 	public Jpa() {
 		super();
 	}
-	
+
 	//-------------------------------------------------------------------------------------
 	// JPA IMPORTS
 	//-------------------------------------------------------------------------------------
-	@VelocityMethod ( 
-		text= { 
-			"Returns a list of all the Java classes required by the current entity for JPA",
-			"( this version always returns 'javax.persistence.*' )"
-		},
-		parameters = {
-			"entity : the entity "
-		},
-		example={	
-			"#foreach( $import in $jpa.imports($entity) )",
-			"import $import;",
-			"#end" 
-		},
-		since = "2.0.7"
+	@VelocityMethod (
+			text= {
+					"Returns a list of all the Java classes required by the current entity for JPA",
+					"( this version always returns 'javax.persistence.*' )"
+			},
+			parameters = {
+					"entity : the entity "
+			},
+			example={
+					"#foreach( $import in $jpa.imports($entity) )",
+					"import $import;",
+					"#end"
+			},
+			since = "2.0.7"
 	)
 	@VelocityReturnType("List of 'String'")
-	//public List<String> imports(JavaBeanClass entity) 
-	public List<String> imports(EntityInContext entity) 
+	//public List<String> imports(JavaBeanClass entity)
+	public List<String> imports(EntityInContext entity)
 	{
 		ImportsList _importsJpa = buildJpaImportsList(entity) ;
 		if ( _importsJpa != null )
@@ -82,18 +82,18 @@ public class Jpa {
 		}
 		return VOID_STRINGS_LIST ;
 	}
-	
+
 	//private JavaBeanClassImports getImports(JavaBeanClass entity) {
 	private ImportsList buildJpaImportsList(EntityInContext entity) {
 		ImportsList jpaImports = new ImportsList();
 
 		jpaImports.declareType("javax.persistence.*");
-		
+
 		/*
 		jpaImports.declareType("javax.persistence.Entity");
 		jpaImports.declareType("javax.persistence.Table");
 		jpaImports.declareType("javax.persistence.Id");
-		
+
 		jpaImports.declareType("javax.persistence.UniqueConstraint");
 		jpaImports.declareType("javax.persistence.EmbeddedId");
 		jpaImports.declareType("javax.persistence.Embeddable");
@@ -115,150 +115,150 @@ public class Jpa {
 	//-------------------------------------------------------------------------------------
 	// ENTITY JPA ANNOTATIONS
 	//-------------------------------------------------------------------------------------
-	@VelocityMethod ( 
-		text= { 
-			"Returns a multiline String containing all the Java JPA annotations required for the current entity",
-			"with the given left marging before each line"
-		},
-		parameters = {
-			"leftMargin : the left margin (number of blanks)",
-			"entity : the entity to be annotated"
-		},
-		example={	
-			"$jpa.entityAnnotations(4, $entity)"
-		},
-		since = "2.0.7"
+	@VelocityMethod (
+			text= {
+					"Returns a multiline String containing all the Java JPA annotations required for the current entity",
+					"with the given left marging before each line"
+			},
+			parameters = {
+					"leftMargin : the left margin (number of blanks)",
+					"entity : the entity to be annotated"
+			},
+			example={
+					"$jpa.entityAnnotations(4, $entity)"
+			},
+			since = "2.0.7"
 	)
 	//public String entityAnnotations(int iLeftMargin, JavaBeanClass entity)
 	public String entityAnnotations(int iLeftMargin, EntityInContext entity)
-    {
+	{
 		AnnotationsBuilder b = new AnnotationsBuilder(iLeftMargin);
-		
+
 		b.addLine("@Entity");
-		
+
 		String s = "@Table(name=\"" + entity.getDatabaseTable() + "\"" ;
 		if ( ! StrUtil.nullOrVoid( entity.getDatabaseSchema() ) ) {
-			s = s + ", schema=\"" + entity.getDatabaseSchema() + "\"" ; 
+			s = s + ", schema=\"" + entity.getDatabaseSchema() + "\"" ;
 		}
 		if ( ! StrUtil.nullOrVoid( entity.getDatabaseCatalog() ) ) {
-			s = s + ", catalog=\"" + entity.getDatabaseCatalog() + "\"" ; 
+			s = s + ", catalog=\"" + entity.getDatabaseCatalog() + "\"" ;
 		}
 		s = s + " )" ;
 
 		b.addLine(s);
-		
+
 		return b.getAnnotations();
-    }
-	
+	}
+
 	//-------------------------------------------------------------------------------------
 	// LINK JPA ANNOTATIONS
 	//-------------------------------------------------------------------------------------
 	@VelocityMethod(
-		text={	
-			"Returns a string containing all the JPA annotations for the given link",
-			"The list of mapped fields is used to determine if a JoinColumn is already mapped as a field",
-			"If a JoinColumn is based on a field already mapped then 'insertable=false, updatable=false' is set"
+			text={
+					"Returns a string containing all the JPA annotations for the given link",
+					"The list of mapped fields is used to determine if a JoinColumn is already mapped as a field",
+					"If a JoinColumn is based on a field already mapped then 'insertable=false, updatable=false' is set"
 			},
-		example={ 
-			"$jpa.linkAnnotations( 4, $link, $listOfMappedFields )" },
-		parameters = { 
-			"leftMargin : the left margin (number of blanks)",
-			"link : the link to be annotated",
-			"alreadyMappedFields : list of all the fields already mapped by JPA as 'simple fields' "},
-		since = "2.0.7"
-			)
+			example={
+					"$jpa.linkAnnotations( 4, $link, $listOfMappedFields )" },
+			parameters = {
+					"leftMargin : the left margin (number of blanks)",
+					"link : the link to be annotated",
+					"alreadyMappedFields : list of all the fields already mapped by JPA as 'simple fields' "},
+			since = "2.0.7"
+	)
 	public String linkAnnotations( int marginSize, LinkInContext entityLink, List<AttributeInContext> alreadyMappedFields )
-				throws GeneratorException {
-		
+			throws GeneratorException {
+
 		//Link   _link         = entityLink.getLink();
-		
+
 		//Entity _targetEntity = entityLink.getTargetEntity() ;
 		//String targetEntityClassName = entityLink.getTargetEntitySimpleType() ; // refactoring v 2.1.0
 		String targetEntityClassName = entityLink.getTargetEntity().getName();
 
 		AnnotationsBuilder annotations = new AnnotationsBuilder(marginSize);
-		
-		//if ( _link.isOwningSide() ) 
-		if ( entityLink.isOwningSide() ) 
+
+		//if ( _link.isOwningSide() )
+		if ( entityLink.isOwningSide() )
 		{
-			//if (_link.isTypeOneToOne()) 
-			if ( entityLink.isCardinalityOneToOne() ) 
+			//if (_link.isTypeOneToOne())
+			if ( entityLink.isCardinalityOneToOne() )
 			{
 				// Examples :
-				//   @OneToOne 
-			    //   @JoinColumn(name="BADGE_NUMBER", referencedColumnName="BADGE_NUMBER")
+				//   @OneToOne
+				//   @JoinColumn(name="BADGE_NUMBER", referencedColumnName="BADGE_NUMBER")
 
-				annotations.addLine(getOwningSideCardinalityAnnotation( entityLink, "OneToOne", null ) ); 
+				annotations.addLine(getOwningSideCardinalityAnnotation( entityLink, "OneToOne", null ) );
 				//processJoinColumns(annotations, _link.getJoinColumns(), ONE_TO_ONE, fieldsList );
 				processJoinColumns(annotations, entityLink, entityLink.getJoinColumns(), alreadyMappedFields );
-			} 
-			//else if (_link.isTypeManyToOne()) 
-			else if ( entityLink.isCardinalityManyToOne() ) 
+			}
+			//else if (_link.isTypeManyToOne())
+			else if ( entityLink.isCardinalityManyToOne() )
 			{
-				annotations.addLine(getOwningSideCardinalityAnnotation( entityLink, "ManyToOne", null ) ); 
+				annotations.addLine(getOwningSideCardinalityAnnotation( entityLink, "ManyToOne", null ) );
 				//processJoinColumns(annotations, _link.getJoinColumns(), MANY_TO_ONE, fieldsList );
 				processJoinColumns(annotations, entityLink, entityLink.getJoinColumns(), alreadyMappedFields );
-			} 
-			//else if (_link.isTypeManyToMany()) 
-			else if ( entityLink.isCardinalityManyToMany() ) 
+			}
+			//else if (_link.isTypeManyToMany())
+			else if ( entityLink.isCardinalityManyToMany() )
 			{
-				annotations.addLine(getOwningSideCardinalityAnnotation( entityLink, "ManyToMany", targetEntityClassName ) ); 
+				annotations.addLine(getOwningSideCardinalityAnnotation( entityLink, "ManyToMany", targetEntityClassName ) );
 				//processJoinTable(annotations, _link.getJoinTable(), MANY_TO_MANY) ;
 				processJoinTable(annotations, entityLink) ;
 			}
-			//else if (_link.isTypeOneToMany()) 
-			else if ( entityLink.isCardinalityOneToMany() ) 
+			//else if (_link.isTypeOneToMany())
+			else if ( entityLink.isCardinalityOneToMany() )
 			{
 				//--- Possible for unidirectional "OneToMany" relationship ( whithout inverse side )
-				annotations.addLine(getOwningSideCardinalityAnnotation( entityLink, "OneToMany", targetEntityClassName ) ); 
-				//processJoinTable(annotations, _link.getJoinTable(), ONE_TO_MANY) ;				
-				processJoinTable(annotations, entityLink) ;				
-			} 
-			else 
-			{
-				// Error 
+				annotations.addLine(getOwningSideCardinalityAnnotation( entityLink, "OneToMany", targetEntityClassName ) );
+				//processJoinTable(annotations, _link.getJoinTable(), ONE_TO_MANY) ;
+				processJoinTable(annotations, entityLink) ;
 			}
-		} 
-		else 
-		{
-			//--- INVERSE SIDE
-			if (entityLink.isCardinalityOneToOne()) 
+			else
 			{
-				annotations.addLine(getInverseSideCardinalityAnnotation( entityLink, "OneToOne" ) ); 
-			} 
-			else if (entityLink.isCardinalityOneToMany()) 
-			{
-				annotations.addLine(getInverseSideCardinalityAnnotation( entityLink, "OneToMany" ) ); 
-			} 
-			else if (entityLink.isCardinalityManyToMany()) 
-			{
-				annotations.addLine(getInverseSideCardinalityAnnotation( entityLink, "ManyToMany" ) ); 
-			} 
-			else if (entityLink.isCardinalityManyToOne()) 
-			{
-				// Not supposed to occur for an INVERSE SIDE !
-				annotations.addLine(getInverseSideCardinalityAnnotation( entityLink, "ManyToOne" ) ); 
-			} 
-			else 
-			{
-				// Error 
+				// Error
 			}
 		}
-		
+		else
+		{
+			//--- INVERSE SIDE
+			if (entityLink.isCardinalityOneToOne())
+			{
+				annotations.addLine(getInverseSideCardinalityAnnotation( entityLink, "OneToOne" ) );
+			}
+			else if (entityLink.isCardinalityOneToMany())
+			{
+				annotations.addLine(getInverseSideCardinalityAnnotation( entityLink, "OneToMany" ) );
+			}
+			else if (entityLink.isCardinalityManyToMany())
+			{
+				annotations.addLine(getInverseSideCardinalityAnnotation( entityLink, "ManyToMany" ) );
+			}
+			else if (entityLink.isCardinalityManyToOne())
+			{
+				// Not supposed to occur for an INVERSE SIDE !
+				annotations.addLine(getInverseSideCardinalityAnnotation( entityLink, "ManyToOne" ) );
+			}
+			else
+			{
+				// Error
+			}
+		}
+
 		return annotations.getAnnotations();
 	}
-	
+
 	//----------------------------------------------------------------
 	/**
 	 * Build an return the cardinality annotation for an "OWNING SIDE"
 	 * Example : "@ManyToOne ( cascade = CascadeType.ALL, fetch = FetchType.EAGER ) "
 	 * @param cardinality
-	 * @param targetEntityClassName the target entity ( or null if none ) 
+	 * @param targetEntityClassName the target entity ( or null if none )
 	 * @return
 	 */
-	private String getOwningSideCardinalityAnnotation( LinkInContext entityLink, String cardinality, String targetEntityClassName ) 
+	private String getOwningSideCardinalityAnnotation( LinkInContext entityLink, String cardinality, String targetEntityClassName )
 	{
-		//Link _link = entityLink.getLink(); 
+		//Link _link = entityLink.getLink();
 
 		StringBuilder sb = new StringBuilder();
 		sb.append( "@" + cardinality ) ;
@@ -273,7 +273,7 @@ public class Jpa {
 				sb.append( ", " );
 			}
 			//--- targetEntity ( for ManyToMany and OneToMany )
-			sb.append( "targetEntity=" + targetEntityClassName + ".class" ) ;			
+			sb.append( "targetEntity=" + targetEntityClassName + ".class" ) ;
 			sb.append( ")" );
 		}
 		else {
@@ -289,7 +289,7 @@ public class Jpa {
 		}
 		return sb.toString();
 	}
-	
+
 	//-------------------------------------------------------------------------------------
 	/**
 	 * Build an return the cardinality annotation for an "INVERSE SIDE"
@@ -297,10 +297,10 @@ public class Jpa {
 	 * @param cardinality
 	 * @return
 	 */
-	private String getInverseSideCardinalityAnnotation( LinkInContext entityLink, String cardinality ) 
-					throws GeneratorException  {
+	private String getInverseSideCardinalityAnnotation( LinkInContext entityLink, String cardinality )
+			throws GeneratorException  {
 		String targetEntityClassName = entityLink.getTargetEntity().getName();
-		
+
 		StringBuilder annotation = new StringBuilder();
 		annotation.append( "@" + cardinality ) ;
 		annotation.append( "(" );
@@ -310,22 +310,22 @@ public class Jpa {
 		String sCardinalityFurtherInformation = getCardinalityFurtherInformation(entityLink);
 		if ( ! StrUtil.nullOrVoid(sCardinalityFurtherInformation)) {
 			annotation.append( sCardinalityFurtherInformation );
-			annotation.append( ", " ); 
+			annotation.append( ", " );
 		}
 		//--- mappedBy - NB : no "mappedBy" for ManyToOne (see JPA javadoc) ( cannot be an inverse side )
-		//if ( ! _link.isTypeManyToOne() ) { 
-		if ( ! entityLink.isCardinalityManyToOne() ) { 
+		//if ( ! _link.isTypeManyToOne() ) {
+		if ( ! entityLink.isCardinalityManyToOne() ) {
 			annotation.append( "mappedBy=\"" + entityLink.getMappedBy() + "\"" );
-			annotation.append( ", " ); 
+			annotation.append( ", " );
 		}
 		//--- targetEntity ( always usable, even with ManyToOne )
 		//annotation.append( "targetEntity=" + _targetEntity.getBeanJavaClass() + ".class" ); // No quote for "targetEntity"
-		annotation.append( "targetEntity=" + targetEntityClassName + ".class" ); // No quotes 
+		annotation.append( "targetEntity=" + targetEntityClassName + ".class" ); // No quotes
 		//---
 		annotation.append( ")" );
 		return annotation.toString();
 	}
-	
+
 	//-------------------------------------------------------------------------------------
 	/**
 	 * Return the further information for the cardinality annotation ( cascade, fetch, optional ) <br>
@@ -340,39 +340,39 @@ public class Jpa {
 		 * JPA documentation
 		 * OneToOne   : cascade + fecth + optional
 		 * ManyToOne  : cascade + fecth + optional
-		 * OneToMany  : cascade + fecth 
-		 * ManyToMany : cascade + fecth 
+		 * OneToMany  : cascade + fecth
+		 * ManyToMany : cascade + fecth
 		 */
 		int n = 0 ;
 		StringBuilder sb = new StringBuilder();
 
-		//--- CASCADE 
-		String sCascade = buildCascade(link); // "cascade = ..." 
+		//--- CASCADE
+		String sCascade = buildCascade(link); // "cascade = ..."
 		if ( ! StrUtil.nullOrVoid( sCascade ) ) {
 			if ( n > 0 ) sb.append(", ");
 			sb.append(sCascade);
 			n++ ;
 		}
 
-		//--- FETCH 
-		String sFetch = buildFetch(link); // "fetch = ..." 
+		//--- FETCH
+		String sFetch = buildFetch(link); // "fetch = ..."
 		if ( ! StrUtil.nullOrVoid( sFetch ) ) {
 			if ( n > 0 ) sb.append(", ");
 			sb.append(sFetch);
 			n++ ;
 		}
-		
+
 		//--- OPTIONAL ( only for OneToOne and ManyToOne )
 		//if ( link.isTypeOneToOne() || link.isTypeManyToOne() ) {
 		if ( link.isCardinalityOneToOne() || link.isCardinalityManyToOne() ) {
-			String sOptional = buildOptional(link); // "optional=true|false" 
+			String sOptional = buildOptional(link); // "optional=true|false"
 			if ( ! StrUtil.nullOrVoid( sOptional ) ) {
 				if ( n > 0 ) sb.append(", ");
 				sb.append(sOptional);
 				n++ ;
 			}
 		}
-		
+
 		return sb.toString();
 	}
 
@@ -387,8 +387,8 @@ public class Jpa {
 	private String buildCascade(LinkInContext link)
 	{
 		// JPA doc : By default no operations are cascaded
-		if ( link.isCascadeALL() ) { 
-			return "cascade = CascadeType.ALL" ; 
+		if ( link.isCascadeALL() ) {
+			return "cascade = CascadeType.ALL" ;
 		}
 		else {
 			int n = 0 ;
@@ -406,25 +406,25 @@ public class Jpa {
 					sb.append("{ ");
 				}
 				int c = 0 ;
-				if ( link.isCascadeMERGE()  ) { 
-					if ( c > 0 ) { sb.append(", "); } 
-					sb.append("CascadeType.MERGE"  ); 
-					c++; 
+				if ( link.isCascadeMERGE()  ) {
+					if ( c > 0 ) { sb.append(", "); }
+					sb.append("CascadeType.MERGE"  );
+					c++;
 				}
-				if ( link.isCascadePERSIST()) { 
-					if ( c > 0 ) { sb.append(", "); } 
-					sb.append("CascadeType.PERSIST"); 
-					c++; 
+				if ( link.isCascadePERSIST()) {
+					if ( c > 0 ) { sb.append(", "); }
+					sb.append("CascadeType.PERSIST");
+					c++;
 				}
-				if ( link.isCascadeREFRESH()) { 
-					if ( c > 0 ) { sb.append(", "); } 
-					sb.append("CascadeType.REFRESH"); 
-					c++; 
+				if ( link.isCascadeREFRESH()) {
+					if ( c > 0 ) { sb.append(", "); }
+					sb.append("CascadeType.REFRESH");
+					c++;
 				}
-				if ( link.isCascadeREMOVE() ) { 
-					if ( c > 0 ) { sb.append(", "); } 
-					sb.append("CascadeType.REMOVE" ); 
-					c++; 
+				if ( link.isCascadeREMOVE() ) {
+					if ( c > 0 ) { sb.append(", "); }
+					sb.append("CascadeType.REMOVE" );
+					c++;
 				}
 				if ( n > 1 ) {
 					sb.append(" }");
@@ -439,25 +439,25 @@ public class Jpa {
 	private String buildFetch(LinkInContext link)
 	{
 		// JPA doc : default = EAGER
-		if ( link.isFetchEAGER() ) { 
-			return "fetch = FetchType.EAGER" ; 
+		if ( link.isFetchEAGER() ) {
+			return "fetch = FetchType.EAGER" ;
 		}
-		if ( link.isFetchLAZY()  ) { 
+		if ( link.isFetchLAZY()  ) {
 			return "fetch = FetchType.LAZY" ;
 		}
 		return "";
 	}
-	
+
 	//-------------------------------------------------------------------------------------
 	//private String buildOptional(Link link)
 	private String buildOptional(LinkInContext link)
 	{
 		// JPA doc : default = true
-		if ( link.isOptionalTrue() ) { 
-			return "optional = true" ; 
+		if ( link.isOptionalTrue() ) {
+			return "optional = true" ;
 		}
-		if ( link.isOptionalFalse() ) { 
-			return "optional = false" ; 
+		if ( link.isOptionalFalse() ) {
+			return "optional = false" ;
 		}
 		return "";
 	}
@@ -470,29 +470,29 @@ public class Jpa {
 	 * @param linkCardinality
 	 * @param alreadyMappedFields
 	 */
-//	private void processJoinColumns(AnnotationsBuilder annotations, JoinColumns joinColumns, 
-//			int linkCardinality, List<AttributeInContext> fieldsList ) 
+//	private void processJoinColumns(AnnotationsBuilder annotations, JoinColumns joinColumns,
+//			int linkCardinality, List<AttributeInContext> fieldsList )
 //	{
-//		if ( joinColumns != null ) 
+//		if ( joinColumns != null )
 //		{
 //			String[] jc = getJoinColumnAnnotations( joinColumns.getAll(), linkCardinality, fieldsList );
 //			if ( jc != null ) {
-//				if ( jc.length == 1 ) 
+//				if ( jc.length == 1 )
 //				{
 //					// Single Join Column
 //					// Example :
-//					//   @JoinColumn(name="MGR_COUNTRY", referencedColumnName="COUNTRY") 
-//					
+//					//   @JoinColumn(name="MGR_COUNTRY", referencedColumnName="COUNTRY")
+//
 //					annotations.addLine( jc[0] );
 //				}
-//				else 
+//				else
 //				{
 //					// Multiple Join Columns
 //					// Example :
 //					// @JoinColumns( {
 //					//   @JoinColumn(name="MGR_COUNTRY", referencedColumnName="COUNTRY") ,
 //					//   @JoinColumn(name="MGR_ID", referencedColumnName="EMP_ID") } )
-//					
+//
 //					annotations.addLine("@JoinColumns( { " );
 //					for ( int i = 0 ; i < jc.length ; i++ ) {
 //						String end = ( i < jc.length - 1) ? "," : " } )" ;
@@ -502,8 +502,8 @@ public class Jpa {
 //			}
 //		}
 //	}
-	
-	private void processJoinColumns(AnnotationsBuilder annotations, LinkInContext link, List<JoinColumnInContext> joinColumns, List<AttributeInContext> alreadyMappedFields ) 
+
+	private void processJoinColumns(AnnotationsBuilder annotations, LinkInContext link, List<JoinColumnInContext> joinColumns, List<AttributeInContext> alreadyMappedFields )
 	{
 		//String[] jc = getJoinColumnAnnotations( joinColumns.getAll(), linkCardinality, fieldsList );
 		String[] jc = getJoinColumnAnnotations( link, joinColumns, alreadyMappedFields );
@@ -511,8 +511,8 @@ public class Jpa {
 			if ( jc.length == 1 ) {
 				// Single Join Column
 				// Example :
-				//   @JoinColumn(name="MGR_COUNTRY", referencedColumnName="COUNTRY") 
-				
+				//   @JoinColumn(name="MGR_COUNTRY", referencedColumnName="COUNTRY")
+
 				annotations.addLine( jc[0] );
 			}
 			else if ( jc.length > 1 ) {
@@ -521,7 +521,7 @@ public class Jpa {
 				// @JoinColumns( {
 				//   @JoinColumn(name="MGR_COUNTRY", referencedColumnName="COUNTRY") ,
 				//   @JoinColumn(name="MGR_ID", referencedColumnName="EMP_ID") } )
-				
+
 				annotations.addLine("@JoinColumns( { " );
 				for ( int i = 0 ; i < jc.length ; i++ ) {
 					String end = ( i < jc.length - 1) ? "," : " } )" ;
@@ -530,7 +530,7 @@ public class Jpa {
 			}
 			// else ( jc.length == 0 ) : no join columns
 		}
-	}	
+	}
 	//-------------------------------------------------------------------------------------
 	/**
 	 * Generates the join table annotation : "@JoinTable"
@@ -538,24 +538,24 @@ public class Jpa {
 	 * @param joinTable
 	 * @param linkCardinality
 	 */
-	//private void processJoinTable(AnnotationsBuilder annotations, JoinTable joinTable, int linkCardinality) 	 
-	private void processJoinTable(AnnotationsBuilder annotations, LinkInContext link ) 	 
+	//private void processJoinTable(AnnotationsBuilder annotations, JoinTable joinTable, int linkCardinality)
+	private void processJoinTable(AnnotationsBuilder annotations, LinkInContext link )
 	{
 		JoinTableInContext joinTable = link.getJoinTable();
 		if ( joinTable != null ) {
 			annotations.addLine("@JoinTable(name=\"" + joinTable.getName() + "\", " );
-			
+
 			//JoinColumns joinColumns = joinTable.getJoinColumns();
 			LinkedList<JoinColumnInContext> joinColumns = joinTable.getJoinColumns();
-			if ( joinColumns != null ) 
+			if ( joinColumns != null )
 			{
 				//processJoinTableColumns(annotations, "joinColumns", joinColumns.getAll(), ",", linkCardinality);
 				processJoinTableColumns(annotations, link, joinColumns, "joinColumns", "," );
 			}
-			
+
 			//InverseJoinColumns inverseJoinColumns = joinTable.getInverseJoinColumns();
 			LinkedList<JoinColumnInContext> inverseJoinColumns = joinTable.getInverseJoinColumns();
-			if ( inverseJoinColumns != null ) 
+			if ( inverseJoinColumns != null )
 			{
 				//processJoinTableColumns(annotations, "inverseJoinColumns", inverseJoinColumns.getAll(), "", linkCardinality);
 				processJoinTableColumns(annotations, link, inverseJoinColumns, "inverseJoinColumns", "" );
@@ -570,27 +570,27 @@ public class Jpa {
 	//-------------------------------------------------------------------------------------
 	//private void processJoinTableColumns( AnnotationsBuilder annotations, String name, JoinColumn[] joinColumns, String end, int linkCardinality )
 	private void processJoinTableColumns( AnnotationsBuilder annotations, LinkInContext link, List<JoinColumnInContext> joinColumns, String name,  String end )
-	
+
 	{
 		//String[] jc = getJoinColumnAnnotations( joinColumns, linkCardinality, null );
 		String[] jc = getJoinColumnAnnotations( link, joinColumns, null );
 		if ( jc != null ) {
-			if ( jc.length == 1 ) 
+			if ( jc.length == 1 )
 			{
 				// Single Join Column
 				// Example :
-				//   joinColumns=@JoinColumn(name="MGR_COUNTRY", referencedColumnName="COUNTRY") 
-				
+				//   joinColumns=@JoinColumn(name="MGR_COUNTRY", referencedColumnName="COUNTRY")
+
 				annotations.addLine("  " + name + "=" + jc[0] + end);
 			}
-			else 
+			else
 			{
 				// Multiple Join Columns
 				// Example :
 				//   joinColumns={
 				//     @JoinColumn(name="MGR_COUNTRY", referencedColumnName="COUNTRY") ,
 				//     @JoinColumn(name="MGR_ID", referencedColumnName="EMP_ID") }
-				
+
 				annotations.addLine("  " + name + "={" );
 				for ( int i = 0 ; i < jc.length ; i++ ) {
 					String jcEnd = ( i < jc.length - 1) ? "," : ( "}"+end ) ;
@@ -599,20 +599,20 @@ public class Jpa {
 			}
 		}
 	}
-	
+
 	//-------------------------------------------------------------------------------------
 	/**
 	 * Returns an array of string containing the annotations <br>
 	 * Example : <br>
 	 *  0 : "@JoinColumn(name="MGR_COUNTRY", referencedColumnName="COUNTRY")"
 	 *  1 : "@JoinColumn(name="MGR_ID", referencedColumnName="EMP_ID")"
-	 *  
+	 *
 	 * @param joinColumns
 	 * @param linkCardinality
 	 * @return
 	 */
-	//private String[] getJoinColumnAnnotations( JoinColumn[] joinColumns, int linkCardinality, List<AttributeInContext> fieldsList ) 
-	private String[] getJoinColumnAnnotations( LinkInContext link, List<JoinColumnInContext> joinColumns, List<AttributeInContext> alreadyMappedFields ) 
+	//private String[] getJoinColumnAnnotations( JoinColumn[] joinColumns, int linkCardinality, List<AttributeInContext> fieldsList )
+	private String[] getJoinColumnAnnotations( LinkInContext link, List<JoinColumnInContext> joinColumns, List<AttributeInContext> alreadyMappedFields )
 	{
 //		if ( null == joinColumns ) return null ;
 //		if ( joinColumns.length == 0 ) return null ;
@@ -621,31 +621,62 @@ public class Jpa {
 //			annotations[i] = getJoinColumnAnnotation(joinColumns[i], linkCardinality, fieldsList);
 //		}
 //		return annotations;
-		
+
+		boolean isAnyColumnAlreadyMappedAsAField = isAnyColumnAlreadyMappedAsAField(joinColumns, alreadyMappedFields);
+
 		String[] annotations = new String[joinColumns.size()];
 		int i = 0 ;
 		for ( JoinColumnInContext jc : joinColumns ) {
-			annotations[i++] = getJoinColumnAnnotation(jc, link, alreadyMappedFields);
+			annotations[i++] = getJoinColumnAnnotation(jc, link, alreadyMappedFields, isAnyColumnAlreadyMappedAsAField);
 		}
 		return annotations;
 	}
-	
+
 	//-------------------------------------------------------------------------------------
 	/**
-	 * Build and return a single "@JoinColumn" annotation 
-	 * @param joinColumn
-	 * @param linkCardinality
+	 * Returns true if any join column is an already mapped field.  This is used internally so all join columns
+	 * have the same insertable and updatable fields
+	 *
+	 * Example : <br>
+	 *  0 : "@JoinColumn(name="WIP_ID", referencedColumnName="WIP_ID", insertable=false, updatable=false)"
+	 *  1 : "@JoinColumn(name="WIP_ID", referencedColumnName="WIP_ID")"
+	 *
+	 *  needs to be
+	 *
+	 *  0 : "@JoinColumn(name="WIP_ID", referencedColumnName="WIP_ID", insertable=false, updatable=false)"
+	 *  1 : "@JoinColumn(name="WIP_ID", referencedColumnName="WIP_ID", insertable=false, updatable=false))"
+	 *
+	 * @param joinColumns
 	 * @param alreadyMappedFields
+	 * @return boolean
+	 */
+	private boolean isAnyColumnAlreadyMappedAsAField(List<JoinColumnInContext> joinColumns, List<AttributeInContext> alreadyMappedFields) {
+		for ( JoinColumnInContext jc : joinColumns ) {
+			if (isColumnAlreadyMappedAsAField(jc, alreadyMappedFields)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	//-------------------------------------------------------------------------------------
+	/**
+	 * Build and return a single "@JoinColumn" annotation
+	 * @param joinColumn
+	 * @param link
+	 * @param alreadyMappedFields
+	 * @param isAnyColumnAlreadyMappedAsAField
 	 * @return
 	 */
 	//private String getJoinColumnAnnotation(JoinColumn joinColumn, int linkCardinality, List<AttributeInContext> mappedFields ) {
-	private String getJoinColumnAnnotation(JoinColumnInContext joinColumn, LinkInContext link, List<AttributeInContext> alreadyMappedFields ) {
+	private String getJoinColumnAnnotation(JoinColumnInContext joinColumn, LinkInContext link, List<AttributeInContext> alreadyMappedFields, boolean isAnyColumnAlreadyMappedAsAField) {
 		StringBuilder annotation = new StringBuilder();
 		annotation.append( "@JoinColumn(");
 		annotation.append( "name=\"" + joinColumn.getName()+"\"" );
 		annotation.append( ", " );
 		annotation.append( "referencedColumnName=\"" + joinColumn.getReferencedColumnName()+"\"" );
-		// TODO 
+		// TODO
 		// columnDefinition
 		// nullable
 		// table
@@ -653,23 +684,26 @@ public class Jpa {
 		//if ( linkCardinality == MANY_TO_ONE || linkCardinality == ONE_TO_ONE ) {
 		if ( link.isCardinalityManyToOne() || link.isCardinalityOneToOne() ) {
 			/*
-			 * Defining "insertable=false, updatable=false" is useful when you need 
+			 * Defining "insertable=false, updatable=false" is useful when you need
 			 * to map a field more than once in an entity, typically:
 			 *  - when using a composite key
 			 *  - when using a shared primary key
 			 *  - when using cascaded primary keys
+			 *
+			 *  Note: isAnyColumnAlreadyMappedAsAField - all columns must have same annotation of insertable and updatable
 			 */
-			if ( isColumnAlreadyMappedAsAField (joinColumn, alreadyMappedFields ) ) {
+			//
+			if (isAnyColumnAlreadyMappedAsAField || isColumnAlreadyMappedAsAField (joinColumn, alreadyMappedFields ) ) {
 				annotation.append( ", " );
-				annotation.append( "insertable=false" ); 
+				annotation.append( "insertable=false" );
 				annotation.append( ", " );
-				annotation.append( "updatable=false" ); 
+				annotation.append( "updatable=false" );
 			}
 		}
 		annotation.append( ")");
 		return annotation.toString();
 	}
-	
+
 	//private boolean isFieldAlreadyMapped (JoinColumn joinColumn, List<AttributeInContext> mappedFields ) {
 	/**
 	 * Returns TRUE if the given 'join column' is already mapped as a simple field 
@@ -691,7 +725,7 @@ public class Jpa {
 		}
 		return false ;
 	}
-	
+
 	//-------------------------------------------------------------------------------------------------------------
 	// J.P.A. ANNOTATIONS FOR FIELDS
 	//-------------------------------------------------------------------------------------------------------------
@@ -724,44 +758,44 @@ public class Jpa {
 //    {
 //		return embeddedIdAnnotations(0, attribute);
 //    }
-	
+
 	@VelocityMethod(
-		text={	
-			"Returns the JPA annotations for the given field (with a left margin)"
+			text={
+					"Returns the JPA annotations for the given field (with a left margin)"
 			},
-		example={ 
-			"$jpa.fieldAnnotations( 4, $field )" },
-		parameters = { 
-			"leftMargin : the left margin (number of blanks) ",
-			"field : the field to be annotated "
+			example={
+					"$jpa.fieldAnnotations( 4, $field )" },
+			parameters = {
+					"leftMargin : the left margin (number of blanks) ",
+					"field : the field to be annotated "
 			},
-		since = "2.0.7"
+			since = "2.0.7"
 	)
 	public String fieldAnnotations(int iLeftMargin, AttributeInContext attribute )
-    {
+	{
 		AnnotationsForJPA annotationsJPA = new AnnotationsForJPA(attribute);
 		return annotationsJPA.getJpaAnnotations(iLeftMargin, AnnotationsForJPA.EMBEDDED_ID_FALSE );
-    }
+	}
 
 	//-------------------------------------------------------------------------------------------------------------
 	@VelocityMethod(
-		text={	
-			"Returns the JPA annotations for an 'embedded id' (with a left margin)",
-			"( there's no '@Id' for an embedded id )"
+			text={
+					"Returns the JPA annotations for an 'embedded id' (with a left margin)",
+					"( there's no '@Id' for an embedded id )"
 			},
-		example={ 
-			"$jpa.embeddedIdAnnotations( 4, $field )" },
-		parameters = { 
-			"leftMargin : the left margin (number of blanks) ",
-			"field : the field to be annotated "
+			example={
+					"$jpa.embeddedIdAnnotations( 4, $field )" },
+			parameters = {
+					"leftMargin : the left margin (number of blanks) ",
+					"field : the field to be annotated "
 			},
-		since = "2.0.7"
-		)
+			since = "2.0.7"
+	)
 	public String embeddedIdAnnotations(int iLeftMargin, AttributeInContext attribute )
-    {
+	{
 		AnnotationsForJPA annotationsJPA = new AnnotationsForJPA(attribute);
 		return annotationsJPA.getJpaAnnotations(iLeftMargin, AnnotationsForJPA.EMBEDDED_ID_TRUE );
-    }
+	}
 	//-------------------------------------------------------------------------------------------------------------
-	
+
 }

--- a/src/test/java/org/telosys/tools/generator/context/JpaTest.java
+++ b/src/test/java/org/telosys/tools/generator/context/JpaTest.java
@@ -1,0 +1,124 @@
+package org.telosys.tools.generator.context;
+
+import junit.env.telosys.tools.generator.fakemodel.AttributeInFakeModel;
+import junit.env.telosys.tools.generator.fakemodel.EntityInFakeModel;
+import org.junit.Test;
+import org.telosys.tools.dsl.generic.model.GenericLink;
+import org.telosys.tools.dsl.generic.model.GenericModel;
+import org.telosys.tools.generator.GeneratorException;
+import org.telosys.tools.generic.model.Cardinality;
+import org.telosys.tools.generic.model.CascadeOptions;
+import org.telosys.tools.generic.model.Entity;
+import org.telosys.tools.generic.model.JoinColumn;
+import org.telosys.tools.generic.model.types.NeutralType;
+import org.telosys.tools.repository.model.JoinColumnInDbModel;
+import org.telosys.tools.repository.model.JoinTableInDbModel;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class JpaTest {
+
+    @Test
+    public void multipleJoinColumnsDoNotHaveInsertableUpdateableAttributesWhenNotAlreadyUsed() throws GeneratorException {
+        Jpa jpa = new Jpa();
+        Entity entity = stubEntity();
+
+        GenericModel genericModel = new GenericModel();
+        genericModel.getEntities().add(stubEntity());
+
+        ModelInContext modelInContext = new ModelInContext(genericModel, "whatever", new EnvInContext());
+        EntityInContext entityInContext = new EntityInContext(entity, "table1", modelInContext, new EnvInContext());
+        modelInContext.getAllEntites().add(entityInContext);
+
+        LinkInContext linkInContext = stubLinkInContext(modelInContext, entityInContext);
+
+        String annotation = jpa.linkAnnotations(5, linkInContext, new ArrayList<AttributeInContext>());
+        assertNotNull(annotation);
+        String toBe = "     @ManyToOne\n" +
+                "     @JoinColumns( { \n" +
+                "         @JoinColumn(name=\"join1\", referencedColumnName=\"ref1\"),\n" +
+                "         @JoinColumn(name=\"join2\", referencedColumnName=\"ref2\") } )";
+
+        assertEquals(toBe, annotation);
+    }
+
+    @Test
+    public void multipleJoinColumnsHaveSameInsertableUpdateableAttributesWhenAnyColumnIsAlreadyUsed() throws GeneratorException {
+        Jpa jpa = new Jpa();
+        Entity entity = stubEntity();
+
+        GenericModel genericModel = new GenericModel();
+        genericModel.getEntities().add(stubEntity());
+
+        ModelInContext modelInContext = new ModelInContext(genericModel, "whatever", new EnvInContext());
+        EntityInContext entityInContext = new EntityInContext(entity, "table1", modelInContext, new EnvInContext());
+        modelInContext.getAllEntites().add(entityInContext);
+
+        LinkInContext linkInContext = stubLinkInContext(modelInContext, entityInContext);
+        AttributeInContext attributeInContext = stubAttributeInContext(modelInContext, entityInContext);
+
+        String annotation = jpa.linkAnnotations(5, linkInContext, Arrays.asList(attributeInContext));
+        assertNotNull(annotation);
+        String toBe = "     @ManyToOne\n" +
+                "     @JoinColumns( { \n" +
+                "         @JoinColumn(name=\"join1\", referencedColumnName=\"ref1\", insertable=false, updatable=false),\n" +
+                "         @JoinColumn(name=\"join2\", referencedColumnName=\"ref2\", insertable=false, updatable=false) } )";
+
+        assertEquals(toBe, annotation);
+    }
+
+    private AttributeInContext stubAttributeInContext(ModelInContext modelInContext, EntityInContext entityInContext) {
+        List<AttributeInContext> mappedFields = new ArrayList<>();
+        AttributeInFakeModel attribute = new AttributeInFakeModel("attribute1", "huh");
+        attribute.setDatabaseName("join1");
+
+        AttributeInContext attributeInContext = new AttributeInContext(entityInContext, attribute, modelInContext, new EnvInContext());
+        mappedFields.add(attributeInContext);
+        return attributeInContext;
+    }
+
+    private LinkInContext stubLinkInContext(ModelInContext modelInContext, EntityInContext entityInContext) {
+        GenericLink link = new GenericLink();
+        link.setOwningSide(true);
+        link.setTargetTableName("table1");
+        link.setCardinality(Cardinality.MANY_TO_ONE);
+        link.setCascadeOptions(new CascadeOptions());
+
+        JoinTableInDbModel joinTable = new JoinTableInDbModel();
+
+        JoinColumnInDbModel joinColumn1 = new JoinColumnInDbModel();
+        joinColumn1.setName("join1");
+        joinColumn1.setReferencedColumnName("ref1");
+
+        JoinColumnInDbModel joinColumn2 = new JoinColumnInDbModel();
+        joinColumn2.setName("join2");
+        joinColumn2.setReferencedColumnName("ref2");
+
+        joinTable.setJoinColumns(Arrays.asList(joinColumn1, joinColumn2));
+        link.setJoinTable(joinTable);
+
+        link.setJoinColumns(Arrays.<JoinColumn>asList(joinColumn1, joinColumn2));
+        return new LinkInContext(entityInContext, link, modelInContext);
+    }
+
+    private Entity stubEntity() {
+        EntityInFakeModel entity = new EntityInFakeModel();
+        entity.setDatabaseTable("table1");
+        entity.setClassName("WHATEVER");
+        entity.storeAttribute(buildIdAttribute1());
+        return entity ;
+    }
+
+    private AttributeInFakeModel buildIdAttribute1() {
+        AttributeInFakeModel a = new AttributeInFakeModel("id", NeutralType.INTEGER);
+        a.setDatabaseName("ID");
+        a.setKeyElement(true);
+        a.setNotNull(true);
+        return a ;
+    }
+}


### PR DESCRIPTION
This is a fix with multiple join columns and a mix of insertable=false, updatable=false.  Spring JPA is complaining that these cannot be mixed for a single field.  I did notice line endings are slightly different in my commit.  Let me know if approach looks OK or if you have questions.  

Thanks.  

Failed
```
    @ManyToOne
    @JoinColumns( { 
        @JoinColumn(name="KEY1", referencedColumnName="KEY1"),
        @JoinColumn(name="KEY2", referencedColumnName="KEY2", insertable=false, updatable=false) } )
```

Passed
```
    @ManyToOne
    @JoinColumns( { 
        @JoinColumn(name="KEY1", referencedColumnName="KEY1", insertable=false, updatable=false),
        @JoinColumn(name="KEY2", referencedColumnName="KEY2", insertable=false, updatable=false) } )
```