### PR TITLE
Fix BigDecimalTest for Java 11

### DIFF
--- a/src/test/java/org/telosys/tools/generator/context/BigDecimalTest.java
+++ b/src/test/java/org/telosys/tools/generator/context/BigDecimalTest.java
@@ -6,6 +6,7 @@ import java.math.BigInteger;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.junit.Assert.assertNull;
 
 public class BigDecimalTest  {
@@ -41,8 +42,10 @@ public class BigDecimalTest  {
 		
 		try {
 			d = new BigDecimal("1AA23.456") ; // OK
+			// We should not execute code below as an exception should have been raised
+			fail("An exception should have been raised due to invalid BigDecimal value");
 		} catch (NumberFormatException e) {
-			assertNull(e.getMessage());// no message
+			// Getting an exception is the expected result
 		}
 	}
 	


### PR DESCRIPTION
Exception message for invalid BigDecimal has changed in Java 11.
Instead of testing that the exception message is `null` the test now only check that an exception is raised.

Closes #10 